### PR TITLE
Improve memory usage with optional cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Vectra is a local vector database for Node.js with features similar to [Pinecone
 
 When queryng Vectra you'll be able to use the same subset of [Mongo DB query operators](https://www.mongodb.com/docs/manual/reference/operator/query/) that Pinecone supports and the results will be returned sorted by simularity. Every item in the index will first be filtered by metadata and then ranked for simularity. Even though every item is evaluated its all in memory so it should by nearly instantanious. Likely 1ms - 2ms for even a rather large index. Smaller indexes should be <1ms.
 
-Keep in mind that your entire Vectra index is loaded into memory so it's not well suited for scenarios like long term chat bot memory. Use a real vector DB for that. Vectra is intended to be used in scenarios where you have a small corpus of mostly static data that you'd like to include in your prompt. Infinite few shot examples would be a great use case for Vectra or even just a single document you want to ask questions over.
+Vectra now loads the index from disk on demand and, by default, caches it in memory for performance. You can disable the cache for long running or memory constrained processes by passing `{ cache: false }` to the `LocalIndex` constructor. This allows the index to be released from memory after each operation, making Vectra more reliable for larger datasets without requiring a separate vector database.
 
 Pinecone style namespaces aren't directly supported but you could easily mimic them by creating a separate Vectra index (and folder) for each namespace.
 
@@ -27,7 +27,8 @@ First create an instance of `LocalIndex` with the path to the folder where you w
 ```typescript
 import { LocalIndex } from 'vectra';
 
-const index = new LocalIndex(path.join(__dirname, '..', 'index'));
+// Disable caching if you need a smaller memory footprint
+const index = new LocalIndex(path.join(__dirname, '..', 'index'), undefined, { cache: false });
 ```
 
 Next, from inside an async function, create your index:

--- a/src/LocalIndex.ts
+++ b/src/LocalIndex.ts
@@ -25,6 +25,7 @@ export interface CreateIndexConfig {
 export class LocalIndex<TMetadata extends Record<string,MetadataTypes> = Record<string,MetadataTypes>>{
     private readonly _folderPath: string;
     private readonly _indexName: string;
+    private readonly _cacheIndexData: boolean;
 
     private _data?: IndexData;
     private _update?: IndexData;
@@ -36,9 +37,10 @@ export class LocalIndex<TMetadata extends Record<string,MetadataTypes> = Record<
      * @param folderPath Path to the index folder.
      * @param indexName Optional name of the index file. Defaults to index.json.
      */
-    public constructor(folderPath: string, indexName?: string) {
+    public constructor(folderPath: string, indexName?: string, options: { cache?: boolean } = {}) {
         this._folderPath = folderPath;
         this._indexName = indexName || "index.json";
+        this._cacheIndexData = options.cache ?? true;
     }
 
     /**
@@ -160,6 +162,7 @@ export class LocalIndex<TMetadata extends Record<string,MetadataTypes> = Record<
             await fs.writeFile(path.join(this._folderPath, this._indexName), JSON.stringify(this._update));
             this._data = this._update;
             this._update = undefined;
+            this.unloadIndexData();
         } catch(err: unknown) {
             throw new Error(`Error saving index: ${(err as any).toString()}`);
         }
@@ -171,11 +174,13 @@ export class LocalIndex<TMetadata extends Record<string,MetadataTypes> = Record<
      */
     public async getIndexStats(): Promise<IndexStats> {
         await this.loadIndexData();
-        return {
+        const stats = {
             version: this._data!.version,
             metadata_config: this._data!.metadata_config,
             items: this._data!.items.length
         };
+        this.unloadIndexData();
+        return stats;
     }
 
     /**
@@ -185,7 +190,9 @@ export class LocalIndex<TMetadata extends Record<string,MetadataTypes> = Record<
      */
     public async getItem<TItemMetadata extends TMetadata = TMetadata>(id: string): Promise<IndexItem<TItemMetadata> | undefined> {
         await this.loadIndexData();
-        return this._data!.items.find(i => i.id === id) as any | undefined;
+        const item = this._data!.items.find(i => i.id === id) as any | undefined;
+        this.unloadIndexData();
+        return item;
     }
 
     /**
@@ -228,7 +235,9 @@ export class LocalIndex<TMetadata extends Record<string,MetadataTypes> = Record<
      */
     public async listItems<TItemMetadata extends TMetadata = TMetadata>(): Promise<IndexItem<TItemMetadata>[]> {
         await this.loadIndexData();
-        return this._data!.items.slice() as any;
+        const items = this._data!.items.slice() as any;
+        this.unloadIndexData();
+        return items;
     }
 
     /**
@@ -240,7 +249,9 @@ export class LocalIndex<TMetadata extends Record<string,MetadataTypes> = Record<
      */
     public async listItemsByMetadata<TItemMetadata extends TMetadata = TMetadata>(filter: MetadataFilter): Promise<IndexItem<TItemMetadata>[]> {
         await this.loadIndexData();
-        return this._data!.items.filter(i => ItemSelector.select(i.metadata, filter)) as any;
+        const items = this._data!.items.filter(i => ItemSelector.select(i.metadata, filter)) as any;
+        this.unloadIndexData();
+        return items;
     }
 
     /**
@@ -319,8 +330,9 @@ export class LocalIndex<TMetadata extends Record<string,MetadataTypes> = Record<
                     score: res[1]
                 });
             });
-            
+
         }
+        this.unloadIndexData();
         return top;
     }
 
@@ -357,6 +369,15 @@ export class LocalIndex<TMetadata extends Record<string,MetadataTypes> = Record<
 
         const data = await fs.readFile(path.join(this._folderPath, this.indexName));
         this._data = JSON.parse(data.toString());
+    }
+
+    /**
+     * Releases any cached index data from memory.
+     */
+    protected unloadIndexData(): void {
+        if (!this._update && !this._cacheIndexData) {
+            this._data = undefined;
+        }
     }
 
     private async addItemToUpdate(item: Partial<IndexItem<any>>, unique: boolean): Promise<IndexItem> {


### PR DESCRIPTION
## Summary
- add optional `cache` constructor argument for `LocalIndex`
- release index data from memory after operations
- document new caching behaviour in README

## Testing
- `yarn build` *(fails: package not in lockfile)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684def05434c83209a34782fb4163313